### PR TITLE
Make AiutaVideoSurface full-width in empty image selector

### DIFF
--- a/fashion-tryon-compose/src/commonMain/kotlin/com/aiuta/fashionsdk/tryon/compose/ui/internal/screens/selector/content/empty/body/ImageSelectorScreenEmptyBodyBlock.kt
+++ b/fashion-tryon-compose/src/commonMain/kotlin/com/aiuta/fashionsdk/tryon/compose/ui/internal/screens/selector/content/empty/body/ImageSelectorScreenEmptyBodyBlock.kt
@@ -55,6 +55,10 @@ internal fun ImageSelectorScreenEmptyBodyBlock(modifier: Modifier) {
 
     val shouldShowConsent = remember { mutableStateOf(false) }
 
+    val sharedModifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 40.dp)
+
     LaunchedEffect(Unit) {
         shouldShowConsent.value = standaloneImagePickerPageFeature?.let {
             controller.consentInteractor.shouldShowConsent(standaloneImagePickerPageFeature)
@@ -67,14 +71,13 @@ internal fun ImageSelectorScreenEmptyBodyBlock(modifier: Modifier) {
             .background(
                 color = theme.color.neutral,
                 shape = RoundedCornerShape(24.dp),
-            )
-            .padding(horizontal = 40.dp),
+            ),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Spacer(Modifier.height(50.dp))
 
         AiutaVideoSurface(
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f),
             video = resolveByMode(
@@ -87,7 +90,7 @@ internal fun ImageSelectorScreenEmptyBodyBlock(modifier: Modifier) {
         Spacer(Modifier.height(50.dp))
 
         Text(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = sharedModifier,
             text = imageSelectorFeature.strings.imagePickerTitleEmpty,
             style = theme.label.typography.titleM,
             color = theme.color.primary,
@@ -97,7 +100,7 @@ internal fun ImageSelectorScreenEmptyBodyBlock(modifier: Modifier) {
         Spacer(Modifier.height(16.dp))
 
         Text(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = sharedModifier,
             text = resolveByMode(
                 propertyName = "imageSelectorFeature.images.example",
                 general = { imageSelectorFeature.strings.imagePickerDescriptionEmpty },
@@ -112,7 +115,7 @@ internal fun ImageSelectorScreenEmptyBodyBlock(modifier: Modifier) {
             Spacer(Modifier.height(16.dp))
 
             ProtectionBlock(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = sharedModifier,
                 protectionFeature = protectionFeature,
             )
         }
@@ -120,7 +123,7 @@ internal fun ImageSelectorScreenEmptyBodyBlock(modifier: Modifier) {
         Spacer(Modifier.height(32.dp))
 
         FashionButton(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = sharedModifier,
             text = imageSelectorFeature.strings.imagePickerButtonUploadImage,
             style = FashionButtonStyles.primaryStyle(theme),
             size = FashionButtonSizes.lSize(),
@@ -144,7 +147,7 @@ internal fun ImageSelectorScreenEmptyBodyBlock(modifier: Modifier) {
             Spacer(Modifier.height(20.dp))
 
             Text(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = sharedModifier,
                 text = predefinedModelFeature.strings.predefinedModelOr,
                 style = theme.label.typography.subtle,
                 color = theme.color.primary,
@@ -154,7 +157,7 @@ internal fun ImageSelectorScreenEmptyBodyBlock(modifier: Modifier) {
             Spacer(Modifier.height(20.dp))
 
             FashionButton(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = sharedModifier,
                 text = predefinedModelFeature.strings.predefinedModelPageButton,
                 style = FashionButtonStyles.adaptiveContrastStyle(theme),
                 size = FashionButtonSizes.lSize(),


### PR DESCRIPTION
## What

In `ImageSelectorScreenEmptyBodyBlock`, the placeholder video (`AiutaVideoSurface`) was constrained by the parent `Column`'s inner `padding(horizontal = 40.dp)`, so it didn't reach the edges of the rounded neutral surface.

- Removed `.padding(horizontal = 40.dp)` from the `Column` modifier (the rounded `background` and outer `26.dp` padding are unchanged).
- Extracted `Modifier.fillMaxWidth().padding(horizontal = 40.dp)` into a `sharedModifier` and applied it to every other content child (titles, description, `ProtectionBlock`, both `FashionButton`s) so they keep the same 40.dp inset.
- `AiutaVideoSurface` now uses `Modifier.fillMaxWidth().weight(1f)` and spans the full `Column` width.

## Why

The video placeholder should be full-bleed within the card while the surrounding text and buttons keep their horizontal inset.

## Notes for reviewers

- All children remain direct siblings of the same `Column`, so the `ColumnScope` weights (`weight(1f)` on the video and the trailing `Spacer(weight(0.5f))`) are untouched — vertical distribution is unchanged.
- Also fixed a latent bug: `AiutaVideoSurface` was reusing the screen-level `modifier` passed into the block instead of its own `Modifier`.
- The video reaches the rounded background's left/right edges; not clipped to the 24.dp corners (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Resolve #657
