### PR TITLE
Force GENERAL mode for multi-product try-on

### DIFF
--- a/fashion-tryon-compose/src/commonMain/kotlin/com/aiuta/fashionsdk/tryon/compose/ui/internal/navigation/TryOnNavigationInitialisation.kt
+++ b/fashion-tryon-compose/src/commonMain/kotlin/com/aiuta/fashionsdk/tryon/compose/ui/internal/navigation/TryOnNavigationInitialisation.kt
@@ -76,7 +76,10 @@ internal fun TryOnNavigationInitialisation(
                     aiuta = { aiutaConfiguration.aiuta },
                 ),
                 LocalAiutaTryOnLoadingActionsController provides rememberAiutaTryOnLoadingActionsController(),
-                LocalAiutaMode provides mode,
+                LocalAiutaMode provides resolveAiutaMode(
+                    productConfiguration = productConfiguration,
+                    mode = mode,
+                ),
             ) {
                 // Init listeners
                 val loadingActionsController = LocalAiutaTryOnLoadingActionsController.current
@@ -88,4 +91,19 @@ internal fun TryOnNavigationInitialisation(
             }
         }
     }
+}
+
+/**
+ * Resolves the final [AiutaMode] that should be provided to [LocalAiutaMode].
+ *
+ * When more than one product is requested for generation, the flow always runs
+ * in [AiutaMode.GENERAL]; otherwise the externally provided [mode] is used.
+ */
+private fun resolveAiutaMode(
+    productConfiguration: ProductConfiguration,
+    mode: AiutaMode,
+): AiutaMode = if (productConfiguration.productsForGeneration.size > 1) {
+    AiutaMode.GENERAL
+} else {
+    mode
 }


### PR DESCRIPTION
## Context

The `mode` passed into `AiutaTryOnFlow` flows unchanged down to `LocalAiutaMode`. For a multi-product generation scenario (more than one product in `ProductConfiguration.productsForGeneration`), the SDK must always operate in `GENERAL` mode regardless of what the caller passed (e.g. `SHOES` only makes sense for a single product).

## Change

Added a private `resolveAiutaMode(...)` helper in `TryOnNavigationInitialisation` that resolves the final mode provided to `LocalAiutaMode`:

- `productsForGeneration.size > 1` → force `AiutaMode.GENERAL`
- otherwise → pass through the externally supplied `mode`

Wired it into the existing `LocalAiutaMode provides ...` site. No new imports needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Resolve #664
