### PR TITLE
Fall back to general model selector when shoes mode is not configured

### DIFF
--- a/fashion-tryon-compose/src/commonMain/kotlin/com/aiuta/fashionsdk/tryon/compose/ui/internal/screens/model/ModelSelectorNavigation.kt
+++ b/fashion-tryon-compose/src/commonMain/kotlin/com/aiuta/fashionsdk/tryon/compose/ui/internal/screens/model/ModelSelectorNavigation.kt
@@ -1,6 +1,7 @@
 package com.aiuta.fashionsdk.tryon.compose.ui.internal.screens.model
 
 import com.aiuta.fashionsdk.configuration.mode.AiutaMode
+import com.aiuta.fashionsdk.configuration.mode.shoes.AiutaShoesMode
 import com.aiuta.fashionsdk.internal.navigation.controller.AiutaNavigationController
 import com.aiuta.fashionsdk.tryon.compose.ui.internal.navigation.TryOnScreen
 
@@ -8,12 +9,23 @@ import com.aiuta.fashionsdk.tryon.compose.ui.internal.navigation.TryOnScreen
  * Routes to the predefined-model selector matching the current [mode] — the centred-pager
  * [TryOnScreen.ModelSelector] for [AiutaMode.GENERAL] or the view-blocks
  * [TryOnScreen.ModelSelectorShoes] for [AiutaMode.SHOES].
+ *
+ * When [mode] is [AiutaMode.SHOES] but [shoesMode] is not configured ([shoesMode] is `null`),
+ * falls back to the general [TryOnScreen.ModelSelector] so we never land on the shoes selector
+ * without a backing shoes configuration.
  */
-internal fun AiutaNavigationController.navigateToModelSelector(mode: AiutaMode) {
+internal fun AiutaNavigationController.navigateToModelSelector(
+    mode: AiutaMode,
+    shoesMode: AiutaShoesMode?,
+) {
     navigateTo(
         newScreen = when (mode) {
             AiutaMode.GENERAL -> TryOnScreen.ModelSelector
-            AiutaMode.SHOES -> TryOnScreen.ModelSelectorShoes
+            AiutaMode.SHOES -> if (shoesMode != null) {
+                TryOnScreen.ModelSelectorShoes
+            } else {
+                TryOnScreen.ModelSelector
+            }
         },
     )
 }

--- a/fashion-tryon-compose/src/commonMain/kotlin/com/aiuta/fashionsdk/tryon/compose/ui/internal/screens/selector/content/empty/body/ImageSelectorScreenEmptyBodyBlock.kt
+++ b/fashion-tryon-compose/src/commonMain/kotlin/com/aiuta/fashionsdk/tryon/compose/ui/internal/screens/selector/content/empty/body/ImageSelectorScreenEmptyBodyBlock.kt
@@ -162,7 +162,10 @@ internal fun ImageSelectorScreenEmptyBodyBlock(modifier: Modifier) {
                 style = FashionButtonStyles.adaptiveContrastStyle(theme),
                 size = FashionButtonSizes.lSize(),
                 onClick = {
-                    navigationController.navigateToModelSelector(mode)
+                    navigationController.navigateToModelSelector(
+                        mode = mode,
+                        shoesMode = configuration.modes.shoes,
+                    )
                 },
             )
 

--- a/fashion-tryon-compose/src/commonMain/kotlin/com/aiuta/fashionsdk/tryon/compose/ui/internal/sheets/picker/ImagePickerSheet.kt
+++ b/fashion-tryon-compose/src/commonMain/kotlin/com/aiuta/fashionsdk/tryon/compose/ui/internal/sheets/picker/ImagePickerSheet.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.aiuta.fashionsdk.analytics.events.AiutaAnalyticsPickerEventType
 import com.aiuta.fashionsdk.compose.resources.drawable.AiutaIcon
+import com.aiuta.fashionsdk.compose.uikit.composition.LocalAiutaConfiguration
 import com.aiuta.fashionsdk.compose.uikit.composition.LocalTheme
 import com.aiuta.fashionsdk.compose.uikit.resources.AiutaIcon
 import com.aiuta.fashionsdk.compose.uikit.utils.clickableUnindicated
@@ -60,6 +61,7 @@ internal fun ImagePickerSheet(
     val navigationController = LocalAiutaNavigationController.current
     val logger = LocalAiutaLogger.current
     val mode = LocalAiutaMode.current
+    val configuration = LocalAiutaConfiguration.current
 
     val cameraFeature = provideFeature<AiutaImagePickerCameraFeature>()
     val photoGalleryFeature = provideFeature<AiutaImagePickerPhotoGalleryFeature>()
@@ -182,7 +184,10 @@ internal fun ImagePickerSheet(
 
                             is AiutaImagePickerPredefinedModelFeature -> {
                                 bottomSheetNavigator.hide()
-                                navigationController.navigateToModelSelector(mode)
+                                navigationController.navigateToModelSelector(
+                                    mode = mode,
+                                    shoesMode = configuration.modes.shoes,
+                                )
                             }
 
                             else -> throw NotSupportedImageSourceException()


### PR DESCRIPTION
## Context

The predefined-model entry in the image selector routed purely on `AiutaMode`: `navigateToModelSelector(mode)` always opened `TryOnScreen.ModelSelectorShoes` when `mode == SHOES`, even if `configuration.modes.shoes` was `null`. That could land the user on the shoes selector with no backing shoes configuration.

## Changes

- `navigateToModelSelector` now takes `shoesMode: AiutaShoesMode?` and falls back to the general `TryOnScreen.ModelSelector` when shoes mode is not configured (mirrors the existing `orModeFallback` pattern in `ModeCheckUtils.kt`).
- Both call sites — `ImageSelectorScreenEmptyBodyBlock` and `ImagePickerSheet` — pass `configuration.modes.shoes`.

### Resulting behavior

| mode | predefinedModelFeature | AiutaShoesMode | → screen |
|------|------|------|------|
| GENERAL | ✓ | — | `ModelSelector` |
| SHOES | ✓ | present | `ModelSelectorShoes` |
| SHOES | ✓ | absent | `ModelSelector` (fallback) |

## Verification

`./gradlew :fashion-tryon-compose:compileCommonMainKotlinMetadata` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Resolve #663
